### PR TITLE
Easing a SITE/ID record restriction to enable EUREF/EPN SINEX handling

### DIFF
--- a/lib/LINZ/GNSS/SinexFile.pm
+++ b/lib/LINZ/GNSS/SinexFile.pm
@@ -387,7 +387,7 @@ sub _scanSiteId
              \s([\s\w]{4})  # point id
              \s([\s\w]{2})  # point code
              \s(.{9})       # monument id
-             \s\w           # Observation techniques
+             \s[\s\w]       # Observation techniques
              \s(.{22})      # description
              \s([\s\-\d]{3}[\-\s\d]{3}[\-\s\d\.]{5}) # longitude DMS
              \s([\s\-\d]{3}[\-\s\d]{3}[\-\s\d\.]{5}) # latitude DMS


### PR DESCRIPTION
Enables using SINEX files of the EUREF Permanent GNSS Network.
Namely [ftp://epncb.oma.be/epncb/station/coord/EPN/EPN_A_IGb14.SNX.Z](url)