### PR TITLE
feat: Basic support for nine character ids GSR-569

### DIFF
--- a/lib/LINZ/GNSS/DataCenter.pm
+++ b/lib/LINZ/GNSS/DataCenter.pm
@@ -243,8 +243,11 @@ sub new
     if( $scheme eq 'file' )
     {
         # File DataCenters are used for writing data, so need to support all data types
-        my $unsupported=join(', ',$LINZ::GNSS::FileTypeList::defaultTypes->unsupportedTypes($filetypes));
-        croak("Output DataCenter $name doesn't support the following file types: $unsupported\n") if $unsupported;
+        if( ! $cfgdc->{readonly} )
+        {
+            my $unsupported=join(', ',$LINZ::GNSS::FileTypeList::defaultTypes->unsupportedTypes($filetypes));
+            croak("Output DataCenter $name doesn't support the following file types: $unsupported\n") if $unsupported;
+        }
     }
     else
     {

--- a/lib/LINZ/GNSS/DataCenter/File.pm
+++ b/lib/LINZ/GNSS/DataCenter/File.pm
@@ -4,6 +4,7 @@ use strict;
 package LINZ::GNSS::DataCenter::File;
 use base "LINZ::GNSS::DataCenter";
 use fields qw (
+    readonly
     );
 
 use Carp;
@@ -13,6 +14,7 @@ sub new
 {
     my($self,$cfgdc)=@_;
     $self=fields::new($self) unless ref $self;
+    $self->{readonly}=1 if $cfgdc->{readonly};
     $self->SUPER::new($cfgdc);
     return $self;
 }
@@ -45,6 +47,11 @@ sub hasfile
 sub putfile
 {
     my ($self,$source,$spec) = @_;
+    if( $self->{readonly} )
+    {
+        $self->SUPER::putfile($source,$spec) if $self->{readonly};
+        return;
+    }
     my $target=$spec->{path};
     $target = $self->{basepath}.'/'.$target if $self->{basepath};
     LINZ::GNSS::DataCenter::makepublicpath($target) || croak "Cannot create target directory $target\n"; 

--- a/lib/LINZ/GNSS/IGSSiteLog.pm
+++ b/lib/LINZ/GNSS/IGSSiteLog.pm
@@ -112,6 +112,7 @@ sub readAscii
             $key =~ s/^iersDomes/iersDOMES/;
             $key =~ s/^([xyz])Coordinate/$1CoordinateInMeters/;
             $key =~ s/^fourCharacterId/fourCharacterID/;
+            $key =~ s/^nineCharacterId/nineCharacterID/;
             $key =~ s/^latitude$/latitude-North/;
             $key =~ s/^longitude$/longitude-East/;
             $key =~ s/^elevation$/elevation-m_ellips./;
@@ -241,7 +242,7 @@ Return the four character code from the site log identification section.
 sub code
 {
     my($self)=@_;
-    return $self->{id}->{fourCharacterID};
+    return $self->{id}->{fourCharacterID} || substr($self->{id}->{nineCharacterID},0,4);
 }
 
 =head2 $name=$sitelog->name


### PR DESCRIPTION
Allows for alternative 4 character or 9 character station ID (9 character is updated IGS site naming to support multiple jurisdictions having the same 4 character code).

This fix just supports reading 9 character ids and returning the first four characters as the code.  