### PR TITLE
S3 filecache

### DIFF
--- a/lib/LINZ/GNSS/AwsS3Bucket.pm
+++ b/lib/LINZ/GNSS/AwsS3Bucket.pm
@@ -69,7 +69,7 @@ sub new()
         $value = $cfg->get('s3_'.$item,'') if $cfg && ! $value;
         $self->{$item}=$value;
     }
-    # $self->{debug_aws}=1 if  $ENV{LINZGNSS_DEBUG_AWS} eq 'debug';
+    $self->{debug_aws}=1 if  $ENV{LINZGNSS_DEBUG_AWS} eq 'debug';
     my $bucket=$self->bucket;
     $self->error("LINZ::GNSS::AwsS3Bucket::new - bucket name not defined\n") if ! $bucket;
     my $awsbin=$self->{aws_client};
@@ -162,10 +162,10 @@ sub _runAws
             next if $k eq $idenv || $k eq $keyenv;
             $cmdstr .= "\n$k=$ENV{$k}";
         }
-        $self->debug($cmdstr);
+        $self->debug($cmdstr) if $self->_debug_aws > 1;
         $ok=run(\@command,\$in,\$out,\$err);
-        $self->debug("Output: $out");
-        $self->debug("Error: $err")
+        $self->debug("Output: $out") if $self->_debug_aws > 1;
+        $self->debug("Error: $err") if $self->_debug_aws > 0;
     };
     if( $@ )
     {

--- a/lib/LINZ/GNSS/DataCenter/S3Bucket.pm
+++ b/lib/LINZ/GNSS/DataCenter/S3Bucket.pm
@@ -70,4 +70,14 @@ sub getfile
     $self->{_logger}->info("Retrieved $file ($size bytes) from $name");
 }
 
+sub putfile
+{
+    my($self,$source, $spec)=@_;
+    my $target=$spec->{path}.'/'.$spec->{filename};
+    $self->{bucket}->putFile($source,$target);
+    my $size=-s $source;
+    my $name=$self->{name};
+    $self->{_logger}->info("Uploaded $target ($size bytes) to $name");
+}
+
 1;

--- a/lib/LINZ/GNSS/DataCenter/S3Bucket.pm
+++ b/lib/LINZ/GNSS/DataCenter/S3Bucket.pm
@@ -34,6 +34,7 @@ Connect to S3 bucket
 sub connect
 {
     my($self) = @_;
+    return if $self->{bucket};
     my $bucketname=$self->host;
     my ($user,$pwd) = $self->credentials(0);
     eval
@@ -64,15 +65,28 @@ sub connect
 sub getfile
 {
     my($self,$path,$file,$target)=@_;
+    $self->connect;
     $self->{bucket}->getFile("$path/$file",$target);
     my $size=-s $target;
     my $name=$self->{name};
     $self->{_logger}->info("Retrieved $file ($size bytes) from $name");
 }
 
+
+# Check to see a file is in the bucket
+
+sub hasfile
+{
+    my($self,$spec)=@_;
+    $self->connect;
+    my $target=$spec->{path}.'/'.$spec->{filename};
+    return $self->{bucket}->fileExists($target);
+}
+
 sub putfile
 {
     my($self,$source, $spec)=@_;
+    $self->connect;
     my $target=$spec->{path}.'/'.$spec->{filename};
     $self->{bucket}->putFile($source,$target);
     my $size=-s $source;


### PR DESCRIPTION
Adds support for a writeable S3 DataCenter, and for using it as a simplified file cache (Cache in the getdata configuration).

Simplified = it does not use a requests database.  The database was implemented for a more complex use case that was never used, which is recording requests for files which could be subsequently filled by another process.   The simplified approach is just to fail if a file is not available.  

The database also supports purging the cache based on file usage/lifecycle information held in the database.  The S3 cache will require an external process to purge the cache (eg S3 object lifecycle).