### PR TITLE
feat: date limits and alternative formats for datacenter data types

### DIFF
--- a/lib/LINZ/GNSS.pm
+++ b/lib/LINZ/GNSS.pm
@@ -220,19 +220,6 @@ sub LoadConfig
             }
             Log::Log4perl->easy_init({level=>$level, file=>">>$logfile"});
         }
-        elsif( exists $config->{logsettings} )
-        {
-            my $logcfg=$config->{logsettings};
-            my $logfile=$ENV{LINZGNSS_LOG_FILE};
-            if( ! $logfile )
-            {
-                my $logdir=$ENV{LINZGNSS_LOG_DIR};
-                $logdir=_expandvar($config->{logdir}) if ! $logdir;
-                $logfile="$logdir"."/"._expandvar($config->{logfile});
-            }
-            $logcfg =~ s/\[logfilename\]/$logfile/eg;
-            Log::Log4perl->init(\$logcfg);
-        }
         else
         {
             Log::Log4perl->easy_init($WARN);

--- a/lib/LINZ/GNSS/FileCache.pm
+++ b/lib/LINZ/GNSS/FileCache.pm
@@ -323,7 +323,7 @@ sub fillRequest
     $self->_logger->debug("Request $id FillRequest status $status");
     foreach my $dnldfile (@$files)
     {
-        my $ftype = $datacenter->filetypes->getType($dnldfile->type,$dnldfile->subtype);
+        my $ftype = $datacenter->filetypes->getType($dnldfile->type,$dnldfile->subtype)->[0];
         my $fexpiry = time() + $ftype->retention * $SECS_PER_DAY;
         $self->addFile( $id, $dnldfile, $fexpiry );
     }

--- a/lib/LINZ/GNSS/FileType.pm
+++ b/lib/LINZ/GNSS/FileType.pm
@@ -49,6 +49,8 @@ use fields qw(
     retrysecs
     max_delay
     max_delaysecs
+    valid_before
+    valid_after
     );
 
 
@@ -59,6 +61,7 @@ use LINZ::GNSS::Time qw(
     $SECS_PER_HOUR
     $SECS_PER_WEEK
     $GNSSTIME0
+    datetime_seconds
 );
 use LINZ::GNSS::Variables qw(ExpandEnv);
 
@@ -97,6 +100,7 @@ our $hourcodes = {
     '23'=>'x',
     };
 
+
 our $DefaultRetention=100;
 
 
@@ -125,8 +129,9 @@ sub new
     $type=uc($type);
     $subtype=uc($subtype);
     require LINZ::GNSS::FileTypeList;
+    # The default is either the first matching type/subtype in the filetype list or else empty.
     my $default = LINZ::GNSS::FileTypeList->getType($type,$subtype);
-    $default ||= {};
+    $default = $default ? $default->[0] : {};
 
     my $name = $cfgft->{name} || $default->{name} || 'No description available'; 
 
@@ -198,6 +203,30 @@ sub new
     $max_delaysecs *= 60 if $2 !~ /^m/;
     $max_delaysecs *= 24 if $2 =~ /^d/;
 
+    my $valid_before=$cfgft->{valid_before} || $default->{valid_before} || '';
+    if( $valid_before )
+    {
+        eval
+        {
+            $valid_before = datetime_seconds($valid_before);
+        };
+        if( $@ )
+        {
+            croak "Invalid valid_before $valid_before for $type:$subtype\n";
+        }
+    }
+    my $valid_after=$cfgft->{valid_after} || $default->{valid_after} || '';
+    if( $valid_after )
+    {
+        eval
+        {
+            $valid_after = datetime_seconds($valid_after);
+        };
+        if( $@ )
+        {
+            croak "Invalid valid_after $valid_after for $type:$subtype\n";
+        }
+    }   
     $self->{type}=$type;
     $self->{subtype}=$subtype;
     $self->{name}=$name;
@@ -218,6 +247,8 @@ sub new
     $self->{retrysecs}=$retrysecs;
     $self->{max_delay}=$max_delay;
     $self->{max_delaysecs}=$max_delaysecs;
+    $self->{valid_before}=$valid_before;
+    $self->{valid_after}=$valid_after;
 
     return $self;
 }
@@ -320,6 +351,8 @@ sub retention{ return $_[0]->{retention}; }
 sub expires{ return $_[0]->{expires}; }
 sub retry { return $_[0]->{retry}; }
 sub max_delay { return $_[0]->{max_delay }; }
+sub valid_before { return $_[0]->{valid_before}; }
+sub valid_after { return $_[0]->{valid_after}; }
 sub use_station{ return $_[0]->{use_station}; }
 
 =head2 
@@ -399,7 +432,8 @@ Returns three values:
 
 the time the data is expected to be available (timestamp in seconds).
 Returns 0 if the file expires and will never be available for the requested
-time.
+time or the the requested time is outside the valid_before and valid_after
+limits.
 
 =item $retry
 
@@ -415,8 +449,18 @@ the time after which missing data is deemed to be unavailable
 
 sub availableTime
 {
-    my($self,$request) = @_;
+    my($self,$request, $now) = @_;
     # Get the last element if this is a sequence
+
+    $now ||= time();
+    if( $self->valid_before && $request->end_epoch > $self->valid_before )
+    {
+        return 0,0,0;
+    }
+    if( $self->valid_after && $request->start_epoch < $self->valid_after )
+    {
+        return 0,0,0;
+    }
     my $timestamp=$request->end_epoch;
     my $increment=$self->{supplyfreqsecs};
 
@@ -428,7 +472,7 @@ sub availableTime
     if( $self->expires )
     {
         my $failtime=$request->start_epoch+$self->expires*$SECS_PER_DAY;
-        if( $failtime < time() )
+        if( $failtime < $now )
         {
             return 0,0,$failtime;
         }

--- a/lib/LINZ/GNSS/FileTypeList.pm
+++ b/lib/LINZ/GNSS/FileTypeList.pm
@@ -6,12 +6,15 @@ LINZ::GNSS::FileTypeList class defines a set of FileType objects.  These can be 
 types for a particular data source or target. The class wraps a hash of hashes, on type and 
 subtype, and provides accessor and processing functions relating to the group.
 
+Each type/subtype entry is an array ref of one or more FileType objects, as there may be
+multiple definitions of a subtype with different suffixes (eg _1, _2, ...)
+
 =cut
 
 package LINZ::GNSS::FileTypeList;
 use LINZ::GNSS::FileType;
 
-our $defaultTypes={};
+our $DefaultTypes={};
 
 =head2 $list=new LINZ::GNSS::FileTypeList($cfg)
 
@@ -42,7 +45,13 @@ sub clone
     {
         foreach my $subtype(keys(%{$self->{$type}}))
         {
-            $copy->{$type}->{$subtype}=$self->{$type}->{$subtype}->clone();
+            my $subtypes=$self->{$type}->{$subtype};
+            my @newsubtypes=();
+            foreach my $st (@$subtypes)
+            {
+                push(@newsubtypes,$st->clone());
+            }
+            $copy->{$type}->{$subtype}=\@newsubtypes;
         }
     }
     return $copy;
@@ -74,14 +83,46 @@ sub loadTypes
 {
     my ($self, $cfgtypes)=@_;
 
+
     while (my ($type, $subtypedef) = each %$cfgtypes )
     {
+        my $frequencies = {};
+        my $priorities = {};
         $type=uc($type);
-        while (my ($subtype, $cfgft) = each %$subtypedef )
+        while (my ($subtypes, $cfgft) = each %$subtypedef )
         {
-            $subtype=uc($subtype);
-            $self->{$type}->{$subtype} = 
-                new LINZ::GNSS::FileType($type, $subtype, $cfgft );
+            $subtypes=uc($subtypes);
+            my $subtype=$subtypes;
+            $subtype =~ s/_\d+$//; # Remove suffix for multiply defined subtypes
+            my $filetype = new LINZ::GNSS::FileType($type, $subtype, $cfgft);
+            $frequencies->{$subtype} ||= $filetype->frequency;
+            if( $filetype->frequency ne $frequencies->{$subtype} )
+            {
+                my $freq1 = $filetype->frequency;
+                my $freq2 = $frequencies->{$subtype};
+                croak("Conflicting frequency $freq1 and $freq2 for $type:$subtype\n");
+            }
+            if( $filetype->priority )
+            {
+                $priorities->{$subtype} ||= $filetype->priority;
+                if( $filetype->priority != $priorities->{$subtype} )
+                {
+                    my $p1 = $filetype->priority;
+                    my $p2 = $priorities->{$subtype};
+                    croak("Conflicting priority $p1 and $p2 for $type:$subtype\n");
+                }
+            }
+            $self->{$type}->{$subtype} ||= [];
+            push(@{$self->{$type}->{$subtype}}, $filetype);
+        }
+        # Set priorities on subtypes which haven't been set for all variants.
+        foreach my $subtype (keys %$priorities)
+        {
+            my $priority=$priorities->{$subtype};
+            foreach my $ft (@{$self->{$type}->{$subtype}})
+            {
+                $ft->{priority}=$priority;
+            }
         }
     }
     return $self;
@@ -91,7 +132,7 @@ sub loadTypes
 =head2 $list->unsupportedTypes( $otherlist )
 
 Checks that all the types defined in a DataCenter are defined in an another
-data center (or defaultTypes if not defined).
+data center (or DefaultTypes if not defined).
 
 Returns an array of missing types/subtypes
 
@@ -100,7 +141,7 @@ Returns an array of missing types/subtypes
 sub unsupportedTypes
 {
     my ($self,$other)=@_;
-    $other=$other || $defaultTypes;
+    $other=$other || $DefaultTypes;
     my @missing=();
     foreach my $type (keys %$self )
     {
@@ -110,7 +151,6 @@ sub unsupportedTypes
             next;
         }
         my $subtypes=$self->{$type};
-        
         
         foreach my $subtype (keys %$subtypes)
         {
@@ -145,7 +185,7 @@ sub LoadDefaultTypes
 {
     my( $cfg ) = @_;
     my $ftl = new LINZ::GNSS::FileTypeList($cfg->{datatypes});
-    $LINZ::GNSS::FileTypeList::defaultTypes=$ftl;
+    $LINZ::GNSS::FileTypeList::DefaultTypes=$ftl;
 }
 
 =head2 $type = $typelist->getType($type,$subtype)
@@ -156,6 +196,9 @@ does not exist return undefined value.
 Can be called as LINZ::GNSS::FileTypeList->getType($type,$subtype) to return the 
 default settings for the type.
 
+The value returned is an array ref of one or more FileType objects, as there may be
+multiple definitions of a subtype with different suffixes (eg _1, _2, ...)
+
 =cut
 
 sub getType
@@ -163,7 +206,7 @@ sub getType
     my($self,$type,$subtype) = @_;
     $type=uc($type);
     $subtype=uc($subtype);
-    if( ! ref($self) ) { $self = $LINZ::GNSS::FileTypeList::defaultTypes; }
+    if( ! ref($self) ) { $self = $LINZ::GNSS::FileTypeList::DefaultTypes }
     return exists $self->{$type} && exists $self->{$type}->{$subtype} ?
            $self->{$type}->{$subtype} :
            undef;
@@ -175,7 +218,11 @@ Returns a list of types matching the specified type and subtype in a data reques
 highest to lowest priority.  The list will contain more than one element if 
 the subtype is suffixed with '+'.  In this case all subtypes with equal or higher
 priority are included.  Use a subtype of '' to list all subtypes with a priority > 0
-or subtype of '*' to list all subtypes.
+or subtype of '*' to list all subtypes.  
+
+The list will also include all subtypes matching the type and subtype with a suffix of _n
+where n is a number.  This allows for different representations of the same product at 
+different times (eg switch from RINEX2 to RINEX3 filenames).
 
 Can be called as LINZ::GNSS::FileTypeList->getTypes($type,$subtype) to return the 
 default settings for the type.
@@ -185,7 +232,7 @@ default settings for the type.
 sub getTypes
 {
     my ($self, $type, $subtype ) = @_;
-    if( ! ref($self) ) { $self = $LINZ::GNSS::FileTypeList::defaultTypes; }
+    if( ! ref($self) ) { $self = $LINZ::GNSS::FileTypeList::DefaultTypes }
     if( ref($type) )
     {
         my $request=$type;
@@ -202,14 +249,14 @@ sub getTypes
         if( $subtype ne '' && $subtype ne '*' )
         {
             return @result if ! exists $self->{$type}->{$subtype};
-            push(@result,$self->{$type}->{$subtype});
+            push(@result,@{$self->{$type}->{$subtype}});
             $basepriority=$result[0]->{priority};
         }
         if( $plus )
         {
             foreach my $t (values %{$self->{$type}})
             {
-                push(@result,$t) if $t->{priority} > $basepriority || $subtype eq '*';
+                push(@result,@$t) if $t->[0]->{priority} > $basepriority || $subtype eq '*';
             }
             @result = sort {$b->{priority} <=> $a->{priority}} @result;
         }
@@ -220,7 +267,7 @@ sub getTypes
 =head2 @subtypes = $typelist->getSubTypes($type,$plustypes)
 
 Returns a list of valid subtypes for a type.  If $plustypes is true then
-~The list may include '+' types where there is a higher priority option for a type.
+the list may include '+' types where there is a higher priority option for a type.
 
 May be called as LINZ::GNSS::FileTypeList->getSubTypes($type)
 
@@ -229,16 +276,16 @@ May be called as LINZ::GNSS::FileTypeList->getSubTypes($type)
 sub getSubTypes
 {
     my($self,$type,$plustypes) = @_;
-    if( ! ref($self) ) { $self = $LINZ::GNSS::FileTypeList::defaultTypes; }
-    my @types=sort {$b->{priority} <=> $a->{priority} || $a->{subtype} cmp $b->{subtype}} values(%{$self->{$type}});
+    if( ! ref($self) ) { $self = $LINZ::GNSS::FileTypeList::DefaultTypes }
+    my @types=sort {$b->[0]->{priority} <=> $a->[0]->{priority} || $a->[0]->{subtype} cmp $b->[0]->{subtype}} values(%{$self->{$type}});
     my @subtypes=();
     foreach my $t (@types)
     {
-        if( $plustypes && $t->{priority} && $t->{priority} < $types[0]->{priority} )
+        if( $plustypes && $t->[0]->{priority} && $t->[0]->{priority} < $types[0]->[0]->{priority} )
         {
-            push(@subtypes,$t->{subtype}.'+');
+            push(@subtypes,$t->[0]->{subtype}.'+');
         }
-        push(@subtypes,$t->{subtype});
+        push(@subtypes,$t->[0]->{subtype});
     }
     return wantarray ? @subtypes : \@subtypes;
 }
@@ -271,13 +318,13 @@ sub setFilename
     my $freq;
     if( $srctype )
     {
-        $filename=$srctype->filename;
-        $freq=$srctype->frequencysecs;
+        $filename=$srctype->[0]->filename;
+        $freq=$srctype->[0]->frequencysecs;
     }
     my $renamed_types=[];
     foreach my $type ($self->getTypes($type,$subtype))
     {
-        next if defined($freq) && $freq != $type->frequencysecs;
+        next if defined($freq) && $freq != $type->[0]->frequencysecs;
         $type->setFilename($filename);
         push(@$renamed_types,$type);
     }
@@ -303,7 +350,7 @@ sub canSetFilename
     # If new filename is not a subtype then it is just a straight renaming
     return 1 if ! $type2;
     # Otherwise can rename if their have the same frequency
-    return $type1->frequencysecs == $type2->frequencysecs ? 1 : 0;
+    return $type1->[0]->frequencysecs == $type2->[0]->frequencysecs ? 1 : 0;
 }
 
 =head2 @types=$typelist->types()
@@ -315,7 +362,7 @@ Return an array of all types provided by the data source
 sub types
 {
     my($self)=@_;
-    if( ! ref($self) ) { $self = $LINZ::GNSS::FileTypeList::defaultTypes; }
+    if( ! ref($self) ) { $self = $LINZ::GNSS::FileTypeList::DefaultTypes }
     my @basetypes=('ORB','ERP','OBS');
     my @othertypes=grep { $_ ne 'ORB' && $_ ne 'ERP' && $_ ne 'OBS' } sort keys %$self;
     my @result=();
@@ -349,18 +396,21 @@ sub checkRequest
     my($self,$request,$stncodes,$subtype,$now) = @_;
     my $files = undef;
     my $available=0;
+    my $retry = 0;
     $now ||= time();
     foreach my $type ( $self->getTypes($request) )
     {
-        next if $subtype && $type->subtype ne $subtype;
-        my ($time)=$type->availableTime($request);
+        my ($time,$tretry,$failtime)=$type->availableTime($request);
         next if ! $time;
         $available=$time if  ! $available || $time < $available;
         next if $time > $now;
+        $retry ||= $tretry;
+        $retry=$tretry if $tretry && $tretry < $retry;
+
         $files = $type->fileList($request,$stncodes);
         last;
     }
-    return $available, $files;
+    return $available, $files, $retry;
 }
 
 =head2 $spec=getSpec($srcspec)
@@ -376,23 +426,7 @@ sub getFilespec
     my $subtype = $srcspec->{subtype};
     return undef if ! exists $self->{$type};
     return undef if ! exists $self->{$type}->{$subtype};
-    return $self->{$type}->{$subtype}->getFilespec($srcspec,$stncodes);
-}
-
-=head2 $spec=getFilespecType($filespec)
-
-Gets the file type matching the FileSpec object
-
-=cut
-
-sub getFilespecType
-{
-    my($self,$srcspec,$stncodes) = @_;
-    my $type = $srcspec->{type};
-    my $subtype = $srcspec->{subtype};
-    return undef if ! exists $self->{$type};
-    return undef if ! exists $self->{$type}->{$subtype};
-    return $self->{$type}->{$subtype};
+    return $self->{$type}->{$subtype}->[0]->getFilespec($srcspec,$stncodes);
 }
 
 

--- a/lib/LINZ/GNSS/Time.pm
+++ b/lib/LINZ/GNSS/Time.pm
@@ -77,10 +77,9 @@ our $SECS_PER_WEEK = $SECS_PER_DAY * 7;
 our @alpha_hours   = qw(a b c d e f g h i j k l m n o p q r s t u v w x);
 our $DATERE        = qr/
                      (\d{4})
-                     (?:\-|\s+)
                      (?:
-                        (\d\d)(?:\-|\s+)(\d\d)|
-                        (\d\d\d)
+                        (?:(?:\-|\s+)(\d\d)(?:\-|\s+)(\d\d))|
+                        (?:(?:\-|\s+|\:)(\d\d\d))
                      )
                      (?:
                      (?:\s+|T\s*)

--- a/lib/LINZ/GNSS/Variables.pm
+++ b/lib/LINZ/GNSS/Variables.pm
@@ -56,7 +56,7 @@ sub _expand
     }
     $errmsg .= ' for '.$context if $context;
     $errmsg .= "\n";
-    croak $errmsg;
+    die $errmsg;
 }
 
 sub ExpandEnv

--- a/test/getdata.conf
+++ b/test/getdata.conf
@@ -5,12 +5,6 @@ AnonymousFtpPassword  positionz@linz.govt.nz
 FtpPassive            default
 #
 ScratchDir            /tmp
-#
-#  Base filename for station prediction models
-#
-
-RefStationFilename  ${POSITIONZ_REFSTATION_DIR||${D||/var/lib/bernese52/datapool}/LINZ/ref_stations}/[ssss].xml 
-RefStationCacheDir  ${POSITIONZ_REFSTATION_DIR||${D||/var/lib/bernese52/datapool}/LINZ/ref_stations}/.cache
 
 # Ranking factors for selecting reference stations.
 #
@@ -50,7 +44,11 @@ RankCosineFactor     10
 # type             The data type
 # subtype          The data subtype
 #
-#
+# Note: a DataCenter can support multiple definitions of a subtype by adding
+# a _### suffix to the subtype, where ### is any integer.  This allows for
+# multiple definitions of a subtype to be defined for different time periods
+# or alternative file naming conventions.
+
 # DataTypes: These are the naming convensions used in the local repository.
 # Any data downloaded from a data center that does not conform to these specs
 # will be converted. The defined data format are also the defaults used for
@@ -98,9 +96,15 @@ RankCosineFactor     10
 #            // will be deemed unavailable
 #            retention 2 days
 #            // The minimum time after downloading for which data will be retained
-#            priorty #
+#            priority #
 #            // The integer priority of the subtype - the lower the value the higher 
 #            // the priority.  
+#            valid_before yyyy:ddd
+#            // Only applies within a DataCenter type definition.  This data type will
+#            // only be used for data before the specified date.
+#            valid_after yyyy:ddd
+#            // Only applies within a DataCenter type definition.  This data type will
+#            // only be used for data after the specified date.
 #        </DAILY>
 #        <HOURLY>
 #            ...
@@ -155,6 +159,22 @@ RankCosineFactor     10
        postsuffix .gz
    </Compression>
 </CompressionTypes>
+
+# If compression type is specified as "auto" then this list is used to 
+# select the type based on the filename.  The first matching regular 
+# expression applies.
+
+CompressionSuffices <<EOD
+    MO\.crx\.gz hatanaka+gzip
+    \d\dd      hatanaka
+    \d\dd\.Z   hatanaka+compress
+    \d\dd\.gz  hatanaka+gzip
+    \.crx      hatanaka
+    \.crx.Z    hatanaka+compress
+    \.crx.gz   hatanaka+gzip
+    \.Z        compress
+    \.gz       gzip
+EOD
 
 <DataTypes>
     <OBS>
@@ -1197,34 +1217,3 @@ RankCosineFactor     10
     # to the data available time to suggest the next time for checking for the data
     queue_latency 1800
 </Cache>
-
-# #
-# # LogSettings: The logging for the Product Manager. These must follow log4perl
-# # config rules.
-# #
-
-LogDir /var/log/bernese52/getdata
-LogFile getdata-${year}-${month}.log
-LogFileRetention 365
-
-LogSettings <<EOF
- log4perl.logger                                    = INFO,Logfile
-# ##############################################################################
-# # Config for the STDOUT Appender
-# ##############################################################################
-# log4perl.appender.Screen                           = Log::Log4perl::Appender::Screen
-# log4perl.appender.Screen.layout                    = Log::Log4perl::Layout::PatternLayout
-# log4perl.appender.Screen.stderr                    = 0
-# log4perl.appender.Screen.layout.ConversionPattern  = %d %p> %F{1}:%L - %m%n
-# ##############################################################################
-# # Config for the Log file Appender (will rotate the file once it is bigger
-# # than 5 Mb )
-# ##############################################################################
-log4perl.appender.Logfile                          = Log::Log4perl::Appender::File
-log4perl.appender.Logfile.filename                 = [logfilename]
-log4perl.appender.Logfile.mode                     = append
-log4perl.appender.Logfile.umask                    = 0002
-log4perl.appender.Logfile.layout                   = Log::Log4perl::Layout::PatternLayout
-log4perl.appender.Logfile.layout.ConversionPattern = %d %p> %F{1}:%L - %m%n
-log4perl.appender.Logfile.TZ                       = NZDT
-EOF


### PR DESCRIPTION
Adds two main features to getdata configuration

* alternative versions of a datatype subtype in a DataCenter with _## suffix (eg DAILY_1,DAILY_2) which are treated as equivalent to subtype DAILY.
* date bounds on a data subtype in a data center as valid_before yyyy:ddd, valid_after yyyy:ddd