### PR TITLE
fix: longitude wrapping in BLQ file

### DIFF
--- a/lib/LINZ/GNSS/BLQFile.pm
+++ b/lib/LINZ/GNSS/BLQFile.pm
@@ -118,7 +118,7 @@ sub readBlqData
         {
             $computed=$1;
         }
-        elsif( $l =~ /^\$\$\s+(\w+)\s*\,?\s+RADI\s+TANG\s+lon\/lat\:\s+(\S+)\s+(\S+)\s+(\S+)\s*$/ )
+        elsif( $l =~ /^\$\$\s+(\w+)\s*\,?\s+RADI\s+TANG\s+lon\/lat\:\s*(\S+)\s+(\S+)(?:\s+(\S+))?\s*$/ )
         {
             ($code,$lon,$lat,$hgt)=($1,$2,$3,$4);
             last;
@@ -350,6 +350,8 @@ sub calcLoadingFromGrid
 {
     my( $self, $code, $lon, $lat )=@_;
     my $index=$self->gridIndex;
+    $lon += 360 while $lon < $index->{lon0};
+    $lon -= 360 while $lon >= $index->{lon0}+360;
     my $glon=($lon-$index->{lon0})/$index->{dlon};
     my $glat=($lat-$index->{lat0})/$index->{dlat};
     my $ilon=floor($glon);


### PR DESCRIPTION
This fixes two issues in processing ocean loading files related to longitudes and longitude wrapping:
* in reading the file stations with negative longitudes <= -100 were ignored as the regular expression test assumed a space before the longitude in the loading header line, but in fact there need not one with these longitudes (eg: 
```
$$ CHTI                    RADI TANG  lon/lat:-176.6171  -43.7355    75.688
```
* matching stations based on the grid did not account for longitude wrapping - extraordinarily undefensive coding - no excuse :-(